### PR TITLE
Fix browser test coverage, run in content-shell

### DIFF
--- a/bin/src/coverage.dart
+++ b/bin/src/coverage.dart
@@ -49,8 +49,11 @@ class Coverage {
     Logger log = new Logger('dcg');
     bool testSuccess = await test.run();
     if (!testSuccess) {
-      log.info(await test.process.stderr.transform(UTF8.decoder).join(''));
+      try {
+        log.info(await test.process.stderr.transform(UTF8.decoder).join(''));
+      } catch(e) {}
       log.severe('Testing failed.');
+      test.kill();
       return false;
     }
     int port = test is BrowserTest ? (test as BrowserTest).observatoryPort : _defaultObservatoryPort;

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,0 +1,21 @@
+@TestOn('content-shell')
+library dart_codecov_generator.test.browser_test;
+
+import 'dart:html';
+
+import 'package:test/test.dart';
+
+bool _dummyCoverage() => true;
+
+void main() {
+  group('Browser Test', () {
+    test('should support importing dart:html', () {
+      var elem = new DivElement();
+      expect(elem is DivElement, isTrue);
+    });
+
+    test('should report coverage for browser tests', () async {
+      expect(_dummyCoverage(), isTrue);
+    });
+  });
+}

--- a/test/env_test.dart
+++ b/test/env_test.dart
@@ -1,3 +1,6 @@
+@TestOn('vm')
+library dart_codecov_generator.test.env_test;
+
 import 'package:test/test.dart';
 
 import '../bin/src/coverage.dart';
@@ -5,9 +8,6 @@ import '../bin/src/env.dart';
 import '../bin/src/executable.dart';
 import '../bin/src/test.dart';
 import '../bin/generate_coverage.dart';
-
-@TestOn('vm')
-
 
 void main() {
   group('Environment', () {


### PR DESCRIPTION
## Issue
- It's better to run coverage for browser tests using content-shell
  - Can pipe console logs to stdout
  - Easier integration with Travis CI
- Browser test run currently doesn't wait properly for tests to finish, resulting in incomplete and inconsistent coverage reporting when running large sets of tests
## Changes

**Source:**
- Switch from Dartium to content-shell
- Listen to the test output from content-shell to determine when the tests are finished

**Tests:**
- Browser tests added to verify the browser use case

---

@stevepeak @johnryan-wf 
