### PR TITLE
Update README.md for changes in the `pub` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: dart
 dart:
   - stable
 script:
+  - pub get --packages-dir
   - pub run test
   - pub run dart_codecov_generator --report-on=bin/ --no-html --verbose test/env_test.dart
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies:
 
 Install:
 ```
-pub get
+pub get --packages-dir
 ```
 
 


### PR DESCRIPTION
> As of Dart 1.20, the `.packages` file has replaced `packages` directories. For backward compatibility, the `pub serve` command still produces a virtual `packages` directory, and the `pub build` command produces an actual `packages` directory in its output directory. To make other `pub` commands create `packages` directories, specify `--packages-dir`. (see https://www.dartlang.org/tools/pub/cmd/pub-get)

Since the implementation of Dart Code Coverage Generator relies on the `packages` directory and for backwards compatibility, the `--packages-dir` option can be used and should be added to the `pub get` command in `README.md`, otherwise one currently gets an error:
```
$ pub get
...
$ pub run dart_codecov_generator
Generating coverage...
Coverage formatting failed.
```

If backwards compatibility is not an issue, the Dart Code Coverage Generator could also just use the `.packages` file instead of `packages` directories, therefore one needs to adjust file `bin/src/coverage.dart
`:
```bin/src/coverage.dart 
@@ -102,7 +102,7 @@ class Coverage {
    'run', 
    'coverage:format_coverage', 
    '-l', 
-   '--package-root=packages', 
+   '--packages=.packages', 
    '-i', 
    collectionOutput.path, 
    '-o', ```