### PR TITLE
Support Dart version <2.13 w/ null-safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: dart
 dart:
   - stable
+  - beta
   - "2.10.3"
   - "2.9.3"
   - "2.8.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dart:
 before_install:
   - sudo apt-get -y install libc6
 script:
-  - pub get --packages-dir
+  - pub get
   - pub run test
   - pub run codecov --report-on=bin/ --no-html --verbose test/env_test.dart
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Depends on the following utilities:
 
 Add this to your package's pubspec.yaml file:
 ```yaml
-dependencies:
-  coverage: "^0.7.0"
-  codecov: "^0.4.0"
+dev_dependencies:
+  coverage: ^0.15.0
+  codecov: ^1.0.0
 ```
 
 Install:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dev_dependencies:
 
 Install:
 ```
-pub get --packages-dir
+pub get
 ```
 
 

--- a/bin/codecov.dart
+++ b/bin/codecov.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/bin/generate_coverage.dart
+++ b/bin/generate_coverage.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/bin/src/coverage.dart
+++ b/bin/src/coverage.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/bin/src/env.dart
+++ b/bin/src/env.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/bin/src/executable.dart
+++ b/bin/src/executable.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/bin/src/test.dart
+++ b/bin/src/test.dart
@@ -1,3 +1,5 @@
+// @dart=2.9
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   logging: ">=0.9.0 <0.12.0"
   path: "^1.6.3"
 environment:
-  sdk: ">=2.0.0 <2.13.0"
+  sdk: ">=2.12.0-0 <2.13.0"
 dev_dependencies:
   coverage: "0.13.11"
   test: "1.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   logging: ">=0.9.0 <0.12.0"
   path: "^1.6.3"
 environment:
-  sdk: ">=2.0.0 <2.11.0"
+  sdk: ">=2.0.0 <2.13.0"
 dev_dependencies:
   coverage: "0.13.11"
   test: "1.12.0"


### PR DESCRIPTION
The 1.0.0 release (#22) removed the support for Dart versions with null-safety.

Probably, because they did break the CI:
https://travis-ci.org/github/codecov/dart/jobs/743493917

This PR aims to add support back in.

Also, includes some clean-up of unsupported/out-dated documentation.